### PR TITLE
verifyCheckCharacters_AllCSET32: Remove duplicate

### DIFF
--- a/cs/HealthcareGMNTests/UnitTest1.cs
+++ b/cs/HealthcareGMNTests/UnitTest1.cs
@@ -184,7 +184,6 @@ namespace HealthcareGMNTests
             Assert.True(VerifyCheckCharacters("23956qk1&dB!23"));
             Assert.True(VerifyCheckCharacters("794394895ic045"));
             Assert.True(VerifyCheckCharacters("57453Uq3qA<H67"));
-            Assert.True(VerifyCheckCharacters("62185314IvwmYZ"));
             Assert.True(VerifyCheckCharacters("0881063PhHvY89"));
         }
 

--- a/java/HealthcareGMNTests.java
+++ b/java/HealthcareGMNTests.java
@@ -174,7 +174,6 @@ public class HealthcareGMNTests
             assertTrue(verifyCheckCharacters("23956qk1&dB!23"));
             assertTrue(verifyCheckCharacters("794394895ic045"));
             assertTrue(verifyCheckCharacters("57453Uq3qA<H67"));
-            assertTrue(verifyCheckCharacters("62185314IvwmYZ"));
             assertTrue(verifyCheckCharacters("0881063PhHvY89"));
         }
 

--- a/js/healthcaregmn.test.js
+++ b/js/healthcaregmn.test.js
@@ -121,7 +121,6 @@ test('verifyCheckCharacters_AllCSET32', () => {
   expect(HealthcareGMN.verifyCheckCharacters("23956qk1&dB!23")).toBe(true);
   expect(HealthcareGMN.verifyCheckCharacters("794394895ic045")).toBe(true);
   expect(HealthcareGMN.verifyCheckCharacters("57453Uq3qA<H67")).toBe(true);
-  expect(HealthcareGMN.verifyCheckCharacters("62185314IvwmYZ")).toBe(true);
   expect(HealthcareGMN.verifyCheckCharacters("0881063PhHvY89")).toBe(true);
 });
 


### PR DESCRIPTION
Removes duplicate "62185314IvwmYZ" case from `verifyCheckCharacters_AllCSET32()`.